### PR TITLE
feat(influxdb-v2): Support InfluxDB v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+/error*.log
+
+# Token created during provisioning for InfluxDB v2; used only for tests.
+/.token

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,65 @@
 .PHONY: test
 
-CONTAINER_NAME=influxdb-test
+CONTAINER_NAME_V1=influxdb-test-v1
+CONTAINER_NAME_V2=influxdb-test-v2
+
 SHELL=bash
 
-start_influx: stop_influx
+USERNAME=myuser
+PASSWORD=mysecretpassword
+STORAGE=myinflux
+
+start_influx: start_influx_v1 start_influx_v2
+
+start_influx_v1: stop_influx_v1
 	docker run -tid -p 8087:8086 \
 	-p 8089:8089/udp \
 	-e INFLUXDB_UDP_ENABLED=true \
-	-e INFLUXDB_DB=myinflux \
+	-e INFLUXDB_DB=${STORAGE} \
 	-e INFLUXDB_HTTP_AUTH_ENABLED=true \
 	-e INFLUXDB_ADMIN_ENABLED=true \
-	-e INFLUXDB_ADMIN_USER=myuser \
-	-e INFLUXDB_ADMIN_PASSWORD=mysecretpassword \
+	-e INFLUXDB_ADMIN_USER=${USERNAME} \
+	-e INFLUXDB_ADMIN_PASSWORD=${PASSWORD} \
 	-v ${PWD}/influxdb-meta.conf:/etc/influxdb/influxdb-meta.conf \
-	--name=${CONTAINER_NAME} influxdb -config /etc/influxdb/influxdb-meta.conf
+	--name=${CONTAINER_NAME_V1} influxdb -config /etc/influxdb/influxdb-meta.conf
 
-wait-for-influx:
-	@echo  "Waiting for InfluxDB: "
+start_influx_v2: stop_influx_v2
+	docker run -tid -p 9999:9999 \
+	--name=${CONTAINER_NAME_V2} quay.io/influxdb/influxdb:2.0.0-beta
+
+wait_for_influx: wait_for_influx_v1 provision_influx_v2
+
+wait_for_influx_v1:
+	@echo  "Waiting for InfluxDB v1: "
 	@i=0; while \
-		!(curl --fail -i 'http://localhost:8087/ping' >error.log 2>&1 ); do \
+		!(curl --fail -i 'http://localhost:8087/ping' >error_v1.log 2>&1 ); do \
 		sleep 1; echo -n '.'; \
-		if [ $$((i+=1)) -gt 60 ] ; then cat error.log ; exit 1; fi;  \
+		if [ $$((i+=1)) -gt 60 ] ; then cat error_v1.log ; exit 1; fi;  \
 		done
 	@echo "DONE"
 
-stop_influx:
-	docker rm -f ${CONTAINER_NAME} || true
+wait_for_influx_v2:
+	@echo  "Waiting for InfluxDB v2: "
+	@i=0; while \
+		!(curl --fail -i 'http://localhost:9999/ping' >error_v2.log 2>&1 ); do \
+		sleep 1; echo -n '.'; \
+		if [ $$((i+=1)) -gt 60 ] ; then cat error_v2.log ; exit 1; fi;  \
+		done
+	@echo "DONE"
 
-test: start_influx wait-for-influx
+provision_influx_v2: wait_for_influx_v2
+	curl -sb -X POST -H "Content-type: application/json" \
+		-d "{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"org\":\"myorg\",\"bucket\":\"${STORAGE}\"}" \
+		http://localhost:9999/api/v2/setup \
+		| jq -j .auth.token > .token
+
+stop_influx: stop_influx_v1 stop_influx_v2
+
+stop_influx_v1:
+	docker rm -f ${CONTAINER_NAME_V1} || true
+
+stop_influx_v2:
+	docker rm -f ${CONTAINER_NAME_V2} || true
+
+test: start_influx wait_for_influx
 	MIX_ENV=test mix test ${file}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # telemetry_influxdb
 InfluxDB reporter for [Telemetry](https://github.com/beam-telemetry/telemetry)
 
-`Telemetry` reporter for InfluxDB compatibile events.
+`Telemetry` reporter for InfluxDB compatible events.
 
   To use it, start the reporter with the `start_link/1` function, providing it a list of
   `Telemetry` event names:
@@ -39,26 +39,33 @@ InfluxDB reporter for [Telemetry](https://github.com/beam-telemetry/telemetry)
 $ make test
 ```
 
-It should setup the latest InfluxDB in docker and run all the tests against it.
+It should setup the latest InfluxDB in docker for both v1 and v2 and runs all the tests against them.
 
 ## Configuration
 
 Possible options for the reporter:
 
- - `:reporter_name` - unique name for the reporter. The purpose is to distinguish between different reporters running in the system.
+### Params for Any Version
+ -  `:version` - :v1 or :v2. The version of InfluxDB to use; defaults to :v1 if not provided
+ -  `:reporter_name` - unique name for the reporter. The purpose is to distinguish between different reporters running in the system.
     One can run separate independent InfluxDB reporters, with different configurations and goals.
- -  `:protocol` - :udp or :http. Which protocol to use for connecting to InfluxDB. Default option is :udp.
+ -  `:protocol` - :udp or :http. Which protocol to use for connecting to InfluxDB. Default option is :udp. InfluxDB v2 only supports :http for now.
  -  `:host` - host, where InfluxDB is running.
  -  `:port` - port, where InfluxDB is running.
- -  `:db` - name of InfluxDB's  instance.
- -  `:username` - username of InfluxDB's user that has writes privileges.
- -   `:password` - password for the user.
  - `:events` - list of `Telemetry` events' names that we want to send to InfluxDB.
     Each event should be specified by the map with the field `name`, e.g. `%{name: [:sample, :event, :name]}`.
     Event names should be compatible with `Telemetry` events' format.
  - `:tags` - list of global tags, that will be attached to each reported event. The format is a map,
     where the key and the value are tag's name and value, respectively.
     Both the tag's name and the value could be atoms or binaries.
+### V1 Only Params
+ -  `:db` - name of the location where time series data is stored in InfluxDB v1
+ -  `:username` - username of InfluxDB's user that has writes privileges. Only required in v1.
+ -  `:password` - password for the user. Only required for v1.
+### V2 Only Params
+ -  `:bucket` - name of the location where time series data is stored in InfluxDB v2
+ -  `:org` -  workspace in InfluxDB v2 where a bucket belongs
+ -  `:token` - InfluxDB v2 authentication token used for authenticating requests. Must have read and write privileges to the bucket and org specified.
 
 ## Notes
 
@@ -79,4 +86,3 @@ TelemetryInfluxDB is copyright (c) 2019 Ludwik Bukowski.
 TelemetryInfluxDB source code is released under MIT license.
 
 See [LICENSE](LICENSE) for more information.
-

--- a/lib/http/event_handler.ex
+++ b/lib/http/event_handler.ex
@@ -40,18 +40,18 @@ defmodule TelemetryInfluxDB.HTTP.EventHandler do
           InfluxDB.config()
         ) :: :ok
   def handle_event(event, measurements, metadata, config) do
-    query = config.host <> ":" <> config.port <> "/write?db=" <> config.db
+    url = build_url(config)
     event_tags = Map.get(metadata, :tags, %{})
     body = Formatter.format(event, measurements, Map.merge(config.tags, event_tags))
 
-    headers =
-      Map.merge(authentication_header(config.username, config.password), binary_data_header())
+    headers = Map.merge(authentication_header(config), binary_data_header())
 
-    :wpool.cast(config.pool_name, {__MODULE__, :send_event, [query, body, headers]})
+    :wpool.cast(config.pool_name, {__MODULE__, :send_event, [url, body, headers]})
   end
 
-  def send_event(query, body, headers) do
-    process_response(HTTPoison.post(query, body, headers))
+  @spec send_event(binary, any, any) :: :ok
+  def send_event(url, body, headers) do
+    process_response(HTTPoison.post(url, body, headers))
   end
 
   def handle_info({:EXIT, _pid, reason}, state) do
@@ -75,8 +75,22 @@ defmodule TelemetryInfluxDB.HTTP.EventHandler do
     :ok
   end
 
-  defp authentication_header(username, password) do
+  defp build_url(%{version: :v1, host: host, port: port, db: db}) do
+    query = URI.encode_query(%{db: db})
+    host <> ":" <> port <> "/write?" <> query
+  end
+
+  defp build_url(%{version: :v2, host: host, port: port, org: org, bucket: bucket}) do
+    query = URI.encode_query(%{bucket: bucket, org: org})
+    host <> ":" <> port <> "/api/v2/write?" <> query
+  end
+
+  defp authentication_header(%{version: :v1, username: username, password: password}) do
     %{"Authorization" => "Basic #{Base.encode64(username <> ":" <> password)}"}
+  end
+
+  defp authentication_header(%{version: :v2, token: token}) do
+    %{"Authorization" => "Token #{token}"}
   end
 
   defp binary_data_header() do

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,8 @@ defmodule TelemetryInfluxDB.MixProject do
       {:meck, git: "https://github.com/eproxus/meck", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:worker_pool, "~> 4.0.0"},
-      {:ex_doc, "~> 0.19", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.19", only: :dev, runtime: false},
+      {:nimble_csv, "~> 0.6", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -17,6 +17,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
+  "nimble_csv": {:hex, :nimble_csv, "0.6.0", "a3673f26d41f986774fe6060e309615343d3cb83a6d435754d8b1fdbd5764879", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},

--- a/test/support/flux_parser.ex
+++ b/test/support/flux_parser.ex
@@ -1,0 +1,150 @@
+defmodule TelemetryInfluxDB.Test.FluxParser do
+  alias NimbleCSV.RFC4180, as: CSV
+
+  @column_types %{
+    "boolean" => :boolean,
+    "double" => :double,
+    "string" => :string,
+    "long" => :long,
+    "unsignedLong" => :unsigned_long,
+    "dateTime:RFC3339" => :datetime
+  }
+
+  def parse_tables(csv) do
+    csv
+    |> parse_chunks()
+    |> Enum.flat_map(fn chunk ->
+      table_data =
+        chunk
+        |> extract_table_text()
+        |> parse_csv()
+        |> separate_tables()
+
+      annotation_data =
+        chunk
+        |> extract_annotation_text()
+        |> parse_csv()
+
+      Enum.flat_map(table_data, fn table ->
+        case length(table) do
+          0 ->
+            %{}
+
+          _ ->
+            [column_names | table_rows] = table
+            column_types = annotation_data |> get_column_types()
+            parse_table(table_rows, column_names, column_types)
+        end
+      end)
+    end)
+  end
+
+  defp separate_tables(parsed) when parsed == [], do: [[]]
+
+  defp separate_tables([headers | rows]) do
+    table_index = Enum.find_index(headers, fn header -> header == "table" end)
+
+    rows
+    |> Enum.chunk_by(fn row -> Enum.at(row, table_index) end)
+    |> Enum.map(fn table_rows -> List.insert_at(table_rows, 0, headers) end)
+  end
+
+  def get_column_types(annotation_data) do
+    col_types_index =
+      annotation_data
+      |> Enum.find_index(fn a -> List.first(a) == "#datatype" end)
+
+    annotation_data
+    |> Enum.at(col_types_index)
+  end
+
+  defp parse_table(
+         table,
+         [_datatype | column_names],
+         [_ | column_types]
+       ) do
+    Enum.map(table, fn [_empty | row] -> parse_row(row, column_types, column_names) end)
+  end
+
+  defp parse_row(row, types, columns) do
+    [types, columns, row]
+    |> Enum.zip()
+    |> Enum.map(fn column_info -> type_value(column_info) end)
+    |> Enum.into(%{})
+  end
+
+  defp type_value({raw_type, column, value}) do
+    type = Map.get(@column_types, raw_type)
+    typed_value = parse_value(value, type)
+    {column, typed_value}
+  end
+
+  def extract_table_text(table_text) do
+    table_text
+    |> String.split("\n")
+    |> Enum.filter(fn line -> !String.starts_with?(line, "#") end)
+    |> Enum.join("\n")
+    |> String.trim()
+  end
+
+  def extract_annotation_text(table_text) do
+    table_text
+    |> String.split("\n")
+    |> Enum.filter(fn line -> String.starts_with?(line, "#") end)
+    |> Enum.join("\n")
+    |> String.trim()
+  end
+
+  def parse_chunks(csv) do
+    csv
+    |> String.trim()
+    |> String.split(~r/\n\s*\n/)
+  end
+
+  def parse_value("null", _type), do: nil
+
+  def parse_value("true", :boolean), do: true
+  def parse_value("false", :boolean), do: false
+
+  def parse_value(string, :string), do: string
+
+  def parse_value("NaN", :double), do: NaN
+
+  def parse_value(string, :double) do
+    case Float.parse(string) do
+      {value, _} -> value
+      :error -> raise ArgumentError, "invalid double argument: '#{string}'"
+    end
+  end
+
+  def parse_value(datetime, :datetime) do
+    case DateTime.from_iso8601(datetime) do
+      {:ok, datetime, _offset} -> %{datetime | microsecond: {0, 6}}
+      {:error, _} -> raise ArgumentError, "invalid datetime argument: '#{datetime}'"
+    end
+  end
+
+  def parse_value(raw, :unsigned_long) do
+    value = parse_integer(raw)
+
+    if value < 0 do
+      raise ArgumentError, message: "invalid unsigned_long argument: '#{value}'"
+    end
+
+    value
+  end
+
+  def parse_value(raw, :long), do: parse_integer(raw)
+
+  defp parse_integer("NaN"), do: NaN
+
+  defp parse_integer(raw) do
+    {value, _} = Integer.parse(raw, 10)
+
+    value
+  end
+
+  def parse_csv(csv) do
+    CSV.parse_string(csv, skip_headers: false)
+  end
+end

--- a/test/support/influx_simple_client.ex
+++ b/test/support/influx_simple_client.ex
@@ -1,34 +1,120 @@
 defmodule TelemetryInfluxDB.Test.InfluxSimpleClient do
-  def query(config, query) do
-    url_encoded = URI.encode_query(%{"q" => query})
+  defmodule V1 do
+    def query(config, query) do
+      url_encoded = URI.encode_query(%{"q" => query})
 
-    path =
-      config.host <>
-        ":" <>
-        :erlang.integer_to_binary(config.port) <> "/query?db=" <> config.db <> "&" <> url_encoded
+      path =
+        config.host <>
+          ":" <>
+          :erlang.integer_to_binary(config.port) <>
+          "/query?db=" <> config.db <> "&" <> url_encoded
 
-    headers = authentication_header(config.username, config.password)
-    process_response(HTTPoison.get(path, headers))
+      headers = authentication_header(config.username, config.password)
+      process_response(HTTPoison.get(path, headers))
+    end
+
+    def post(config, query) do
+      url_encoded = URI.encode_query(%{"q" => query})
+
+      path =
+        config.host <>
+          ":" <>
+          :erlang.integer_to_binary(config.port) <>
+          "/query?db=" <> config.db <> "&" <> url_encoded
+
+      headers = authentication_header(config.username, config.password)
+      process_response(HTTPoison.post(path, "", headers))
+    end
+
+    defp process_response({:ok, %HTTPoison.Response{body: body}}) do
+      {:ok, res} = Jason.decode(body)
+      res
+    end
+
+    defp authentication_header(username, password) do
+      %{"Authorization" => "Basic #{Base.encode64(username <> ":" <> password)}"}
+    end
   end
 
-  def post(config, query) do
-    url_encoded = URI.encode_query(%{"q" => query})
+  defmodule V2 do
+    def query(config, query) do
+      org_encoded = URI.encode_query(%{"org" => config.org})
 
-    path =
-      config.host <>
-        ":" <>
-        :erlang.integer_to_binary(config.port) <> "/query?db=" <> config.db <> "&" <> url_encoded
+      body =
+        Jason.encode!(%{
+          dialect: %{annotations: ["datatype"]},
+          query: query
+        })
 
-    headers = authentication_header(config.username, config.password)
-    process_response(HTTPoison.post(path, "", headers))
-  end
+      path =
+        config.host <>
+          ":" <>
+          :erlang.integer_to_binary(config.port) <>
+          "/api/v2/query?" <>
+          org_encoded
 
-  defp process_response({:ok, %HTTPoison.Response{body: body}}) do
-    {:ok, res} = Jason.decode(body)
-    res
-  end
+      headers = headers(config)
+      process_response(HTTPoison.post(path, body, headers))
+    end
 
-  defp authentication_header(username, password) do
-    %{"Authorization" => "Basic #{Base.encode64(username <> ":" <> password)}"}
+    def delete(%{bucket: bucket, org: org} = config, predicate) do
+      # We're required to include a time range, so we create one that
+      # should be large enough to capture all of the data while accounting
+      # for any clock sync issues between the client and server.
+      now = NaiveDateTime.utc_now()
+
+      start =
+        NaiveDateTime.add(now, -3600, :second)
+        |> format_time()
+
+      stop =
+        NaiveDateTime.add(now, 3600, :second)
+        |> format_time()
+
+      query = URI.encode_query(%{bucket: bucket, org: org})
+
+      body =
+        Jason.encode!(%{
+          predicate: predicate,
+          start: start,
+          stop: stop
+        })
+
+      path =
+        config.host <>
+          ":" <>
+          :erlang.integer_to_binary(config.port) <>
+          "/api/v2/delete?" <>
+          query
+
+      headers = headers(config)
+      process_response(HTTPoison.post(path, body, headers))
+    end
+
+    defp format_time(%NaiveDateTime{} = time) do
+      time
+      |> DateTime.from_naive!("Etc/UTC")
+      |> DateTime.to_iso8601()
+    end
+
+    defp process_response({:ok, %HTTPoison.Response{body: body}}) do
+      body
+    end
+
+    defp headers(config) do
+      default_headers()
+      |> Map.merge(authentication_header(config.token))
+    end
+
+    def default_headers() do
+      %{
+        "Accept" => "application/csv",
+        "Content-type" => "application/json"
+      }
+    end
+
+    defp authentication_header(token) do
+      %{"Authorization" => "Token #{token}"}
+    end
   end
 end

--- a/test/telemetry_influx_db_test.exs
+++ b/test/telemetry_influx_db_test.exs
@@ -1,11 +1,15 @@
 defmodule TelemetryInfluxDBTest do
   use ExUnit.Case, async: false
-  alias TelemetryInfluxDB.Test.InfluxSimpleClient
-  alias TelemetryInfluxDB.UDP
+
   import ExUnit.CaptureLog
   import Eventually
 
-  @default_options %{
+  alias TelemetryInfluxDB.Test.FluxParser
+  alias TelemetryInfluxDB.Test.InfluxSimpleClient
+  alias TelemetryInfluxDB.UDP
+
+  @default_config %{
+    version: :v1,
     db: "myinflux",
     username: "myuser",
     password: "mysecretpassword",
@@ -13,11 +17,26 @@ defmodule TelemetryInfluxDBTest do
     protocol: :udp,
     port: 8087
   }
+
+  setup_all do
+    token = File.read!(".token")
+
+    {:ok, %{token: token}}
+  end
+
   describe "Invalid reporter configuration - " do
     test "error log message is displayed for invalid influxdb credentials" do
       # given
       event = given_event_spec([:request, :failed])
-      pid = start_reporter(:http, %{events: [event], username: "badguy", password: "wrongpass"})
+
+      config =
+        make_config(%{version: :v1, protocol: :http}, %{
+          events: [event],
+          username: "badguy",
+          password: "wrongpass"
+        })
+
+      pid = start_reporter(config)
       testpid = self()
 
       :meck.new(TelemetryInfluxDB.HTTP.EventHandler, [:unstick, :passthrough])
@@ -44,7 +63,17 @@ defmodule TelemetryInfluxDBTest do
     test "error log message is displayed for invalid influxdb database" do
       # given
       event = given_event_spec([:users, :count])
-      pid = start_reporter(:http, %{events: [event], db: "yy_postgres"})
+
+      config =
+        make_config(
+          %{
+            version: :v1,
+            protocol: :http
+          },
+          %{events: [event], db: "yy_postgres"}
+        )
+
+      pid = start_reporter(config)
       testpid = self()
       :meck.new(TelemetryInfluxDB.HTTP.EventHandler, [:unstick, :passthrough])
 
@@ -68,44 +97,118 @@ defmodule TelemetryInfluxDBTest do
     end
 
     test "error log message is displayed for missing db for HTTP" do
-      assert_raise(ArgumentError, fn ->
-        @default_options
-        |> Map.delete(:db)
-        |> Map.put(:protocol, :http)
-        |> Map.put(:events, [given_event_spec([:missing, :db])])
-        |> start_reporter()
-      end)
+      assert_raise(
+        ArgumentError,
+        "for http protocol in v1 you need to specify :db field",
+        fn ->
+          @default_config
+          |> Map.delete(:db)
+          |> Map.put(:protocol, :http)
+          |> Map.put(:events, [given_event_spec([:missing, :db])])
+          |> start_reporter()
+        end
+      )
+    end
+
+    test "error message is displayed for missing bucket in v2 config", %{token: token} do
+      assert_raise(
+        ArgumentError,
+        "for InfluxDB v2 you need to specify :bucket, :org, and :token fields",
+        fn ->
+          @default_config
+          |> be_v2(token)
+          |> Map.delete(:bucket)
+          |> Map.put(:events, [given_event_spec([:missing, :bucket])])
+          |> start_reporter()
+        end
+      )
+    end
+
+    test "error message is displayed for missing org in v2 config", %{token: token} do
+      assert_raise(
+        ArgumentError,
+        "for InfluxDB v2 you need to specify :bucket, :org, and :token fields",
+        fn ->
+          @default_config
+          |> be_v2(token)
+          |> Map.delete(:org)
+          |> Map.put(:events, [given_event_spec([:missing, :org])])
+          |> start_reporter()
+        end
+      )
+    end
+
+    test "error message is displayed for invalid version" do
+      assert_raise(
+        ArgumentError,
+        "version must be :v1 or :v2",
+        fn ->
+          @default_config
+          |> Map.put(:version, :bad_version)
+          |> Map.put(:events, [given_event_spec([:invalid, :version])])
+          |> start_reporter()
+        end
+      )
+    end
+
+    test "error message is displayed for missing token in v2 config", %{token: token} do
+      assert_raise(
+        ArgumentError,
+        "for InfluxDB v2 you need to specify :bucket, :org, and :token fields",
+        fn ->
+          @default_config
+          |> be_v2(token)
+          |> Map.delete(:token)
+          |> Map.put(:events, [given_event_spec([:missing, :token])])
+          |> start_reporter()
+        end
+      )
+    end
+
+    test "error message is displayed when specifying udp protocol with v2 config", %{token: token} do
+      assert_raise(
+        ArgumentError,
+        "the udp protocol is not currently supported for InfluxDB v2; please use http instead",
+        fn ->
+          @default_config
+          |> be_v2(token)
+          |> Map.put(:protocol, :udp)
+          |> Map.put(:events, [given_event_spec([:v2, :udp])])
+          |> start_reporter()
+        end
+      )
     end
   end
 
   describe "Events reported - " do
-    for protocol <- [:http, :udp] do
+    for {version, protocol} <- [{:v1, :http}, {:v1, :udp}, {:v2, :http}] do
       @tag protocol: protocol
-      test "event is reported when specified by its name for #{protocol} API", %{
-        protocol: protocol
-      } do
+      @tag version: version
+      test "event is reported when specified by its name for #{version} #{protocol} API",
+           context do
         ## given
         event = given_event_spec([:requests, :failed])
-        pid = start_reporter(protocol, %{events: [event]})
+        config = make_config(context, %{events: [event]})
+        pid = start_reporter(config)
 
         ## when
         :telemetry.execute([:requests, :failed], %{"reason" => "timeout", "retries" => 3})
 
         ## then
-        assert_reported("requests.failed", %{"reason" => "timeout", "retries" => 3})
+        assert_reported(context, "requests.failed", %{"reason" => "timeout", "retries" => 3})
 
         ## cleanup
-        clear_series("requests.failed")
+        clear_series(context, "requests.failed")
         stop_reporter(pid)
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "event is reported with correct data types for #{protocol} API", %{
-        protocol: protocol
-      } do
+      test "event is reported with correct data types for #{version} #{protocol} API", context do
         ## given
         event = given_event_spec([:calls, :failed])
-        pid = start_reporter(protocol, %{events: [event]})
+        config = make_config(context, %{events: [event]})
+        pid = start_reporter(config)
 
         ## when
         :telemetry.execute([:calls, :failed], %{
@@ -117,7 +220,7 @@ defmodule TelemetryInfluxDBTest do
         })
 
         ## then
-        assert_reported("calls.failed", %{
+        assert_reported(context, "calls.failed", %{
           "int" => 4,
           "string_int" => "3",
           "float" => 0.34,
@@ -126,144 +229,155 @@ defmodule TelemetryInfluxDBTest do
         })
 
         ## cleanup
-        clear_series("calls.failed")
+        clear_series(context, "calls.failed")
         stop_reporter(pid)
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "only specified events are reported for #{protocol} API", %{protocol: protocol} do
+      test "only specified events are reported for #{version} #{protocol} API", context do
         ## given
         event1 = given_event_spec([:event, :one])
         event2 = given_event_spec([:event, :two])
         event3 = given_event_spec([:event, :three])
-        pid = start_reporter(protocol, %{events: [event1, event2, event3]})
+        config = make_config(context, %{events: [event1, event2, event3]})
+        pid = start_reporter(config)
         ## when
         :telemetry.execute([:event, :one], %{"value" => 1})
-        assert_reported("event.one", %{"value" => 1})
+        assert_reported(context, "event.one", %{"value" => 1})
 
         :telemetry.execute([:event, :two], %{"value" => 2})
-        assert_reported("event.two", %{"value" => 2})
+        assert_reported(context, "event.two", %{"value" => 2})
 
         :telemetry.execute([:event, :other], %{"value" => "?"})
 
         ## then
-        refute_reported("event.other")
+        refute_reported(context, "event.other")
 
         ## cleanup
-        clear_series("event.one")
-        clear_series("event.two")
-        clear_series("event.other")
+        clear_series(context, "event.one")
+        clear_series(context, "event.two")
+        clear_series(context, "event.other")
         stop_reporter(pid)
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "events are reported with global pre-defined tags for #{protocol} API", %{
-        protocol: protocol
-      } do
+      test "events are reported with global pre-defined tags for #{version} #{protocol} API",
+           context do
         ## given
         event = given_event_spec([:memory, :leak])
 
-        pid =
-          start_reporter(protocol, %{
+        config =
+          make_config(context, %{
             events: [event],
             tags: %{region: :eu_central, time_zone: :cest}
           })
+
+        pid = start_reporter(config)
 
         ## when
         :telemetry.execute([:memory, :leak], %{"memory_leaked" => 100})
 
         ## then
-        assert_reported("memory.leak", %{"memory_leaked" => 100}, %{
+        assert_reported(context, "memory.leak", %{"memory_leaked" => 100}, %{
           "region" => "\"eu_central\"",
           "time_zone" => "\"cest\""
         })
 
         ## cleanup
-        clear_series("memory.leak")
+        clear_series(context, "memory.leak")
         stop_reporter(pid)
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "events are reported with event-specific tags for #{protocol} API", %{
-        protocol: protocol
-      } do
+      test "events are reported with event-specific tags for #{version} #{protocol} API",
+           context do
         ## given
         event = given_event_spec([:system, :crash])
-        pid = start_reporter(protocol, %{events: [event], tags: %{}})
+        config = make_config(context, %{events: [event], tags: %{}})
+        pid = start_reporter(config)
 
         ## when
         :telemetry.execute([:system, :crash], %{"node_id" => "a3"}, %{tags: %{priority: :high}})
 
         ## then
-        assert_reported("system.crash", %{"node_id" => "a3"}, %{
+        assert_reported(context, "system.crash", %{"node_id" => "a3"}, %{
           "priority" => "\"high\""
         })
 
         ## cleanup
-        clear_series("system.crash")
+        clear_series(context, "system.crash")
         stop_reporter(pid)
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "events are reported with special characters for #{protocol} API", %{
-        protocol: protocol
-      } do
+      test "events are reported with special characters for #{version} #{protocol} API",
+           context do
         ## given
         event1 = given_event_spec([:event, :special1])
         event2 = given_event_spec([:event, :special2])
-        pid = start_reporter(protocol, %{events: [event1, event2], tags: %{}})
+        config = make_config(context, %{events: [event1, event2], tags: %{}})
+        pid = start_reporter(config)
 
         ## when
         :telemetry.execute([:event, :special1], %{"equal_sign" => "a=b"}, %{
           tags: %{priority: "hig\"h"}
         })
 
-        :telemetry.execute([:event, :special2], %{"coma_space" => "a,b c"}, %{tags: %{}})
+        :telemetry.execute([:event, :special2], %{"comma_space" => "a,b c"}, %{tags: %{}})
 
         ## then
-        assert_reported("event.special1", %{"equal_sign" => "a\\\=b"}, %{
+        assert_reported(context, "event.special1", %{"equal_sign" => "a\\\=b"}, %{
           "priority" => "\"hig\\\\\"h\""
         })
 
-        assert_reported("event.special2", %{"coma_space" => "a\\,b\\ c"}, %{})
+        assert_reported(context, "event.special2", %{"comma_space" => "a\\,b\\ c"}, %{})
 
         ## cleanup
-        clear_series("event.special1")
-        clear_series("event.special2")
+        clear_series(context, "event.special1")
+        clear_series(context, "event.special2")
         stop_reporter(pid)
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "events are detached after stoping reporter for #{protocol} API", %{
-        protocol: protocol
-      } do
+      test "events are detached after stopping reporter for #{version} #{protocol} API",
+           context do
         ## given
         event_old = given_event_spec([:old, :event])
         event_new = given_event_spec([:new, :event])
-        pid = start_reporter(protocol, %{events: [event_old, event_new]})
+        config = make_config(context, %{events: [event_old, event_new]})
+        pid = start_reporter(config)
 
         :telemetry.execute([:old, :event], %{"value" => 1})
-        assert_reported("old.event", %{"value" => 1})
+        assert_reported(context, "old.event", %{"value" => 1})
 
         ## when
         TelemetryInfluxDB.stop(pid)
         :telemetry.execute([:new, :event], %{"value" => 2})
 
         ## then
-        refute_reported("new.event")
+        refute_reported(context, "new.event")
 
         ## cleanup
-        clear_series("old.event")
+        clear_series(context, "old.event")
       end
 
       @tag :capture_log
+      @tag version: version
       @tag protocol: protocol
-      test "events are not reported when reporter receives an exit signal for #{protocol} API",
-           %{protocol: protocol} do
+      test "events are not reported when reporter receives an exit signal for #{version} #{
+             protocol
+           } API",
+           context do
         ## given
         event_first = given_event_spec([:first, :event])
         event_second = given_event_spec([:second, :event])
-        pid = start_reporter(protocol, %{events: [event_first, event_second]})
+        config = make_config(context, %{events: [event_first, event_second]})
+        pid = start_reporter(config)
 
         Process.unlink(pid)
         {:links, child_pids} = :erlang.process_info(pid, :links)
@@ -279,50 +393,54 @@ defmodule TelemetryInfluxDBTest do
         :telemetry.execute([:first, :event], %{})
         :telemetry.execute([:second, :event], %{})
 
-        refute_reported("first.event")
-        refute_reported("second.event")
+        refute_reported(context, "first.event")
+        refute_reported(context, "second.event")
       end
 
+      @tag version: version
       @tag protocol: protocol
-      test "events are reported from two independed reporters for #{protocol} API", %{
-        protocol: protocol
-      } do
+      test "events are reported from two independent reporters for #{version} #{protocol} API",
+           context do
         ## given
         event1 = given_event_spec([:servers1, :down])
         event2 = given_event_spec([:servers2, :down])
 
-        pid1 =
-          start_reporter(protocol, %{
+        config =
+          make_config(context, %{
             events: [event1],
             tags: %{region: :eu_central, time_zone: :cest},
             reporter_name: "eu"
           })
 
-        pid2 =
-          start_reporter(protocol, %{
+        pid1 = start_reporter(config)
+
+        config =
+          make_config(context, %{
             events: [event2],
             tags: %{region: :asia, time_zone: :other},
             reporter_name: "asia"
           })
+
+        pid2 = start_reporter(config)
 
         ## when
         :telemetry.execute([:servers1, :down], %{"panic?" => "yes"})
         :telemetry.execute([:servers2, :down], %{"panic?" => "yes"})
 
         ## then
-        assert_reported("servers1.down", %{"panic?" => "yes"}, %{
+        assert_reported(context, "servers1.down", %{"panic?" => "yes"}, %{
           "region" => "\"eu_central\"",
           "time_zone" => "\"cest\""
         })
 
-        assert_reported("servers2.down", %{"panic?" => "yes"}, %{
+        assert_reported(context, "servers2.down", %{"panic?" => "yes"}, %{
           "region" => "\"asia\"",
           "time_zone" => "\"other\""
         })
 
         ## cleanup
-        clear_series("servers1.down")
-        clear_series("servers2.down")
+        clear_series(context, "servers1.down")
+        clear_series(context, "servers2.down")
         stop_reporter(pid1)
         stop_reporter(pid2)
       end
@@ -332,7 +450,8 @@ defmodule TelemetryInfluxDBTest do
   @tag :capture_log
   test "notifying a UDP error and fetching a socket returns a new socket" do
     event = given_event_spec([:some, :event3])
-    start_reporter(:udp, %{events: [event], tags: %{}})
+    config = make_config(%{version: :v1, protocol: :udp}, %{events: [event], tags: %{}})
+    start_reporter(config)
     udp = UDP.Connector.get_udp("default")
     Process.exit(udp.socket, :kill)
 
@@ -345,7 +464,9 @@ defmodule TelemetryInfluxDBTest do
   test "events are not reported when reporter is shut down by its supervisor" do
     event_first = given_event_spec([:first, :event])
     event_second = given_event_spec([:second, :event])
-    child_opts = [Map.to_list(@default_options) ++ [events: [event_first, event_second]]]
+    context = %{version: :v1, protocol: :udp}
+    config = make_config(context, %{events: [event_first, event_second]})
+    child_opts = [Map.to_list(config)]
 
     {:ok, supervisor} =
       Supervisor.start_link(
@@ -365,25 +486,70 @@ defmodule TelemetryInfluxDBTest do
     :telemetry.execute([:first, :event], %{})
     :telemetry.execute([:second, :event], %{})
 
-    refute_reported("first.event")
-    refute_reported("second.event")
+    refute_reported(context, "first.event")
+    refute_reported(context, "second.event")
   end
 
   defp given_event_spec(name) do
     %{name: name}
   end
 
-  defp refute_reported(name, config \\ @default_options) do
-    q = "SELECT * FROM \"" <> name <> "\";"
-    res = InfluxSimpleClient.query(config, q)
-    assert %{"results" => [%{"statement_id" => 0}]} == res
+  defp start_reporter(config) do
+    {:ok, pid} =
+      config
+      |> Map.to_list()
+      |> TelemetryInfluxDB.start_link()
+
+    pid
   end
 
-  defp assert_reported(name, values, tags \\ %{}, config \\ @default_options) do
+  defp be_v2(config, token) do
+    config
+    |> Map.drop([:db, :username, :password])
+    |> Map.merge(%{
+      version: :v2,
+      protocol: :http,
+      port: 9999,
+      bucket: "myinflux",
+      org: "myorg",
+      token: token
+    })
+  end
+
+  defp clear_series(context, name) do
+    config = make_assertion_config(context)
+    do_clear_series(config, name)
+
+    eventually(fn ->
+      empty_result?(config, query(config, name))
+    end)
+  end
+
+  defp do_clear_series(%{version: :v1} = config, name) do
+    q = "DROP SERIES FROM \"" <> name <> "\";"
+    InfluxSimpleClient.V1.post(config, q)
+  end
+
+  defp do_clear_series(%{version: :v2} = config, name) do
+    predicate = "_measurement=\"#{name}\""
+    InfluxSimpleClient.V2.delete(config, predicate)
+  end
+
+  defp refute_reported(context, name) do
+    config = make_assertion_config(context)
+    res = query(config, name)
+    assert empty_result?(config, res)
+  end
+
+  defp assert_reported(context, name, values, tags \\ %{}) do
+    config = make_assertion_config(context)
+    do_assert_reported(config, name, values, tags)
+  end
+
+  defp do_assert_reported(%{version: :v1} = config, name, values, tags) do
     assert record =
              eventually(fn ->
-               q = "SELECT * FROM \"" <> name <> "\";"
-               res = InfluxSimpleClient.query(config, q)
+               res = query(config, name)
 
                with [inner_map] <- res["results"],
                     [record] <- inner_map["series"] do
@@ -403,34 +569,89 @@ defmodule TelemetryInfluxDBTest do
     assert tag_and_fields == all_vals
   end
 
-  defp clear_series(name, config \\ @default_options) do
-    q = "DROP SERIES FROM \"" <> name <> "\";"
-    InfluxSimpleClient.post(config, q)
+  defp do_assert_reported(%{version: :v2} = config, name, values, tags) do
+    results =
+      eventually(fn ->
+        res = query(config, name)
 
-    eventually(fn ->
-      q = "SELECT * FROM \"" <> name <> "\";"
-      InfluxSimpleClient.query(config, q) == %{"results" => [%{"statement_id" => 0}]}
+        if empty_result?(config, res) do
+          false
+        else
+          res
+        end
+      end)
+
+    tag_values = Map.values(tags)
+
+    assert Enum.all?(results, fn result ->
+             measurement = Map.get(result, "_measurement")
+
+             result_tag_values =
+               tags
+               |> Map.keys()
+               |> Enum.map(fn key -> Map.get(result, key) end)
+
+             measurement == name and result_tag_values == tag_values
+           end)
+
+    assert Enum.map(results, fn result -> Map.get(result, "_field") end) == Map.keys(values)
+
+    Enum.each(Map.keys(values), fn key ->
+      field_result =
+        Enum.find(results, fn result ->
+          Map.get(result, "_field") == key
+        end)
+
+      assert Map.get(field_result, "_value") == Map.get(values, key)
     end)
   end
 
-  defp start_reporter(:udp, options) do
-    @default_options
+  defp query(%{version: :v1} = config, name) do
+    q = "SELECT * FROM \"" <> name <> "\";"
+    InfluxSimpleClient.V1.query(config, q)
+  end
+
+  defp query(%{version: :v2, bucket: bucket} = config, name) do
+    q = """
+    from(bucket: "#{bucket}")
+    |> range(start: -1m)
+    |> filter(fn: (r) =>
+      r._measurement == "#{name}"
+    )
+    |> group(columns: ["_field"])
+    """
+
+    res = InfluxSimpleClient.V2.query(config, q)
+
+    FluxParser.parse_tables(res)
+  end
+
+  defp empty_result?(%{version: :v1}, %{"results" => [%{"statement_id" => 0}]}), do: true
+  defp empty_result?(%{version: :v2}, res) when res == [], do: true
+  defp empty_result?(_, _), do: false
+
+  defp make_assertion_config(context, overrides \\ %{}) do
+    make_config(%{context | protocol: :http}, overrides)
+  end
+
+  defp make_config(%{version: :v1, protocol: :udp}, overrides) do
+    @default_config
     |> Map.delete(:db)
     |> Map.merge(%{protocol: :udp, port: 8089})
-    |> Map.merge(options)
-    |> start_reporter()
+    |> Map.merge(overrides)
   end
 
-  defp start_reporter(:http, options) do
-    @default_options
+  defp make_config(%{version: :v1, protocol: :http}, overrides) do
+    @default_config
     |> Map.merge(%{protocol: :http, port: 8087})
-    |> Map.merge(options)
-    |> start_reporter()
+    |> Map.merge(overrides)
   end
 
-  defp start_reporter(options) do
-    {:ok, pid} = TelemetryInfluxDB.start_link(options)
-    pid
+  defp make_config(%{version: :v2, protocol: :http, token: token}, overrides) do
+    @default_config
+    |> be_v2(token)
+    |> Map.merge(%{protocol: :http, port: 9999})
+    |> Map.merge(overrides)
   end
 
   defp wait_processes_to_die(pids) do


### PR DESCRIPTION
Update Makefile so that make test will start a v2 docker container and provision a user, organization, and bucket.

If version is specified as `:two`, telemetry metrics will get written to the specified InfluxDB version 2 instance.