### PR TITLE
fix: remove extra layer of quoting/escaping of tag keys and values

### DIFF
--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -11,20 +11,18 @@ defmodule TelemetryInfluxDB.Formatter do
   end
 
   defp format_measurements(measurements) do
-    " " <> comma_separated(measurements)
+    " " <> comma_separated(measurements, &to_bin_quoted/1)
   end
+
+  defp format_tags(tags) when tags == %{}, do: ""
 
   defp format_tags(tags) do
-    if tags != %{} do
-      "," <> comma_separated(binary_map(tags))
-    else
-      ""
-    end
+    "," <> comma_separated(tags, &to_bin/1)
   end
 
-  defp comma_separated(measurements) do
-    measurements
-    |> Enum.map(fn {k, v} -> to_bin(k) <> "=" <> to_bin_quoted(v) end)
+  defp comma_separated(map, format_value) do
+    map
+    |> Enum.map(fn {k, v} -> to_bin(k) <> "=" <> format_value.(v) end)
     |> Enum.join(",")
   end
 
@@ -39,10 +37,6 @@ defmodule TelemetryInfluxDB.Formatter do
   defp to_bin_quoted(val) when is_boolean(val), do: to_bin(val)
   defp to_bin_quoted(val) when is_map(val), do: "\"" <> to_bin(val) <> "\""
   defp to_bin_quoted(val), do: "\"" <> to_bin(val) <> "\""
-
-  defp binary_map(atomized_map) do
-    Map.new(atomized_map, fn {k, v} -> {to_bin(k), to_bin(v)} end)
-  end
 
   # https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/
   defp escape_special_chars(string) do

--- a/test/formatter_test.exs
+++ b/test/formatter_test.exs
@@ -16,14 +16,14 @@ defmodule TelemetryInfluxDB.FormatterTest do
     assert Formatter.format([:rainy, :day], %{"temperature" => 13, "wind" => "medium"}, %{
              topic: :weather
            }) ==
-             "rainy.day,topic=\"weather\" temperature=13,wind=\"medium\""
+             "rainy.day,topic=weather temperature=13,wind=\"medium\""
   end
 
   test "formats the point given binary tags" do
     assert Formatter.format([:snowy, :day], %{"temperature" => -5, "wind" => "medium"}, %{
              "topic" => "weather"
            }) ==
-             "snowy.day,topic=\"weather\" temperature=-5,wind=\"medium\""
+             "snowy.day,topic=weather temperature=-5,wind=\"medium\""
   end
 
   test "formats the point with multiple tags and multiple fields" do
@@ -31,7 +31,7 @@ defmodule TelemetryInfluxDB.FormatterTest do
              "tag1" => "tag1_val",
              "tag2" => "tag2_val"
            }) ==
-             "event,tag1=\"tag1_val\",tag2=\"tag2_val\" field1=\"field1_val\",field2=\"field2_val\""
+             "event,tag1=tag1_val,tag2=tag2_val field1=\"field1_val\",field2=\"field2_val\""
   end
 
   test "properly formats the point with integer" do

--- a/test/telemetry_influx_db_test.exs
+++ b/test/telemetry_influx_db_test.exs
@@ -281,8 +281,8 @@ defmodule TelemetryInfluxDBTest do
 
         ## then
         assert_reported(context, "memory.leak", %{"memory_leaked" => 100}, %{
-          "region" => "\"eu_central\"",
-          "time_zone" => "\"cest\""
+          "region" => "eu_central",
+          "time_zone" => "cest"
         })
 
         ## cleanup
@@ -304,7 +304,7 @@ defmodule TelemetryInfluxDBTest do
 
         ## then
         assert_reported(context, "system.crash", %{"node_id" => "a3"}, %{
-          "priority" => "\"high\""
+          "priority" => "high"
         })
 
         ## cleanup
@@ -326,7 +326,7 @@ defmodule TelemetryInfluxDBTest do
 
         ## then
         assert_reported(context, "database.repo", %{"query_time" => 0.01}, %{
-          "hostname" => "\"host-01\""
+          "hostname" => "host-01"
         })
 
         ## cleanup
@@ -353,7 +353,7 @@ defmodule TelemetryInfluxDBTest do
 
         ## then
         assert_reported(context, "event.special1", %{"equal_sign" => "a\\\=b"}, %{
-          "priority" => "\"hig\\\\\"h\""
+          "priority" => "hig\\\"h"
         })
 
         assert_reported(context, "event.special2", %{"comma_space" => "a\\,b\\ c"}, %{})
@@ -451,13 +451,13 @@ defmodule TelemetryInfluxDBTest do
 
         ## then
         assert_reported(context, "servers1.down", %{"panic?" => "yes"}, %{
-          "region" => "\"eu_central\"",
-          "time_zone" => "\"cest\""
+          "region" => "eu_central",
+          "time_zone" => "cest"
         })
 
         assert_reported(context, "servers2.down", %{"panic?" => "yes"}, %{
-          "region" => "\"asia\"",
-          "time_zone" => "\"other\""
+          "region" => "asia",
+          "time_zone" => "other"
         })
 
         ## cleanup


### PR DESCRIPTION
Fixes the quoting problems we are having as they are also preventing the ecto telemetry metrics from getting successfully written to influxdb.

This could be considered a breaking change since it changes the format of the tag keys and values of the data being written.