### PR TITLE
feat(worker_count): Raise the worker count to 10

### DIFF
--- a/lib/http/pool.ex
+++ b/lib/http/pool.ex
@@ -3,7 +3,7 @@ defmodule TelemetryInfluxDB.HTTP.Pool do
   require Logger
   alias TelemetryInfluxDB, as: InfluxDB
 
-  @default_workers_num 3
+  @default_workers_num 10
 
   @spec child_spec(InfluxDB.config()) :: Supervisor.child_spec()
   def child_spec(config) do


### PR DESCRIPTION
With the current memory usage spiking for our worker pool, it seems that the queue continuously grows in size as it waits for a worker to be ready. We have a lot of available room in CPU so spinning up more workers may help keep the queue size in check. 

The limit of ten was to restrict the number of http calls to the tools cluster.

https://github.com/inaka/worker_pool sets default worker limit to 100, but the repo limits them to 3.