### PR TITLE
fix: test failures

### DIFF
--- a/test/support/flux_parser.ex
+++ b/test/support/flux_parser.ex
@@ -55,6 +55,8 @@ defmodule TelemetryInfluxDB.Test.FluxParser do
     |> Enum.map(fn table_rows -> List.insert_at(table_rows, 0, headers) end)
   end
 
+  def get_column_types([]), do: []
+
   def get_column_types(annotation_data) do
     col_types_index =
       annotation_data

--- a/test/telemetry_influx_db_test.exs
+++ b/test/telemetry_influx_db_test.exs
@@ -623,7 +623,7 @@ defmodule TelemetryInfluxDBTest do
 
   defp assert_tags(%{version: :v1} = config, tags) do
     assert eventually(fn ->
-             res = InfluxSimpleClient.query(config, "SHOW TAG KEYS;")
+             res = InfluxSimpleClient.V1.query(config, "SHOW TAG KEYS;")
 
              with [inner_map] <- res["results"],
                   [record] <- inner_map["series"],


### PR DESCRIPTION
When starting to do some additional work on this library, I found that the tests were failing.

One failure was a missing V1 qualifier which we added.

The other seems to be from a change in the format of empty query results. I'm not sure why or how that changed, since we're still using the same influx 2.0.0-beta Docker container we were using before. The change here handles the case of missing annotations that we are now seeing.

Also submitted upstream: https://github.com/ludwikbukowski/telemetry_influxdb/pull/18