### PR TITLE
Use latest v1/v2 docker images for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ erl_crash.dump
 *.ez
 
 /error*.log
-
-# Token created during provisioning for InfluxDB v2; used only for tests.
-/.token

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SHELL=bash
 USERNAME=myuser
 PASSWORD=mysecretpassword
 STORAGE=myinflux
+TOKEN=mysecrettoken
 
 start_influx: start_influx_v1 start_influx_v2
 
@@ -21,13 +22,20 @@ start_influx_v1: stop_influx_v1
 	-e INFLUXDB_ADMIN_USER=${USERNAME} \
 	-e INFLUXDB_ADMIN_PASSWORD=${PASSWORD} \
 	-v ${PWD}/influxdb-meta.conf:/etc/influxdb/influxdb-meta.conf \
-	--name=${CONTAINER_NAME_V1} influxdb -config /etc/influxdb/influxdb-meta.conf
+	--name=${CONTAINER_NAME_V1} influxdb:1.8 -config /etc/influxdb/influxdb-meta.conf
 
 start_influx_v2: stop_influx_v2
 	docker run -tid -p 9999:8086 \
-	--name=${CONTAINER_NAME_V2} quay.io/influxdb/influxdb:2.0.0-rc
+	-e DOCKER_INFLUXDB_INIT_MODE=setup \
+	-e DOCKER_INFLUXDB_INIT_USERNAME=${USERNAME} \
+	-e DOCKER_INFLUXDB_INIT_PASSWORD=${PASSWORD} \
+	-e DOCKER_INFLUXDB_INIT_ORG=myorg \
+	-e DOCKER_INFLUXDB_INIT_BUCKET=${STORAGE} \
+	-e DOCKER_INFLUXDB_INIT_RETENTION=1w \
+	-e DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${TOKEN} \
+	--name=${CONTAINER_NAME_V2} influxdb:2.0
 
-wait_for_influx: wait_for_influx_v1 provision_influx_v2
+wait_for_influx: wait_for_influx_v1 wait_for_influx_v2
 
 wait_for_influx_v1:
 	@echo  "Waiting for InfluxDB v1: "
@@ -45,23 +53,6 @@ wait_for_influx_v2:
 		sleep 1; echo -n '.'; \
 		if [ $$((i+=1)) -gt 60 ] ; then cat error_v2.log ; exit 1; fi;  \
 		done
-	@echo "DONE"
-
-provision_influx_v2: wait_for_influx_v2
-	@echo "Provisioning InfluxDB v2:"
-	@response=$$(curl -s -X POST http://localhost:9999/api/v2/setup \
-		-H "Content-type: application/json" \
-		-d "{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\",\"org\":\"myorg\",\"bucket\":\"${STORAGE}\"}" \
-		); \
-	token=$$(echo $$response | jq -j .auth.token); \
-	bucket=$$(echo $$response | jq -j .bucket.id); \
-	org=$$(echo $$response | jq -j .org.id); \
-	curl -s -X POST http://localhost:9999/api/v2/dbrps \
-		-H "Authorization: Token $$token" \
-		-H "Content-type: application/json" \
-		-d "{\"bucket_id\": \"$$bucket\",\"database\":\"${STORAGE}\",\"default\":true,\"organization_id\":\"$$org\",\"retention_policy\":\"default-rp\"}" \
-	> error_v2_provision.log 2>&1; \
-	echo -n $$token > .token
 	@echo "DONE"
 
 stop_influx: stop_influx_v1 stop_influx_v2

--- a/test/support/influx_simple_client.ex
+++ b/test/support/influx_simple_client.ex
@@ -57,18 +57,38 @@ defmodule TelemetryInfluxDB.Test.InfluxSimpleClient do
       process_response(HTTPoison.post(path, body, headers))
     end
 
-    def delete_measurement(%{bucket: bucket} = config, measurement) do
-      query = ~s{DROP MEASUREMENT "#{measurement}"}
-      url_encoded = URI.encode_query(%{"q" => query})
+    def delete_measurement(%{bucket: bucket, org: org} = config, measurement) do
+      # We're required to include a time range, so we create one that
+      # should be large enough to capture all of the data while accounting
+      # for any clock sync issues between the client and server.
+      now = NaiveDateTime.utc_now()
+      start = NaiveDateTime.add(now, -3600, :second)
+      stop = NaiveDateTime.add(now, 3600, :second)
+      predicate = "_measurement=\"#{measurement}\""
+      query = URI.encode_query(%{bucket: bucket, org: org})
+
+      body =
+        Jason.encode!(%{
+          predicate: predicate,
+          start: format_time(start),
+          stop: format_time(stop)
+        })
 
       path =
         config.host <>
           ":" <>
           :erlang.integer_to_binary(config.port) <>
-          "/query?db=" <> bucket <> "&" <> url_encoded
+          "/api/v2/delete?" <>
+          query
 
       headers = headers(config)
-      process_response(HTTPoison.get(path, headers))
+      process_response(HTTPoison.post(path, body, headers))
+    end
+
+    defp format_time(%NaiveDateTime{} = time) do
+      time
+      |> DateTime.from_naive!("Etc/UTC")
+      |> DateTime.to_iso8601()
     end
 
     defp process_response({:ok, %HTTPoison.Response{body: body}}) do


### PR DESCRIPTION
**NOTE:** Also submitted upstream as https://github.com/ludwikbukowski/telemetry_influxdb/pull/22

The official `latest` Docker image for InfluxDB is now a 2.x image. That image now supports initial provisioning via environment variables like the 1.x image does.

This makes the following changes:
- Explicitly use a v1.x image (latest is 1.8) for the v1 tests
- Use the DockerHub image for v2 tests
- Use the new image's built-in provisioning support to simplify the Makefile
- Use a hard-coded token to avoid having to inject it everywhere dynamically in the tests
- Revert back to using `/api/v2/delete` for cleaning up after tests. It is now supported again, and the v1 compatibility endpoint wasn't working the same way with the latest version.
- Remove the `.token` file from `.gitignore`; we no longer generate this file.