### PR TITLE
Allow configurable number of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Possible options for the reporter:
  - `:tags` - list of global static tags, that will be attached to each reported event. The format is a map,
     where the key and the value are tag's name and value, respectively.
     Both the tag's name and the value could be atoms or binaries.
+ - `:worker_pool_size` - specify the number of workers to use to send events to InfluxDB via HTTP. Only used when `:protocol` is set to `:http`. (default 3)
 ### V1 Only Options
  - `:db` - name of the location where time series data is stored in InfluxDB v1
  - `:username` - username of InfluxDB's user that has writes privileges. Only required in v1.

--- a/lib/http/pool.ex
+++ b/lib/http/pool.ex
@@ -3,8 +3,6 @@ defmodule TelemetryInfluxDB.HTTP.Pool do
   require Logger
   alias TelemetryInfluxDB, as: InfluxDB
 
-  @default_workers_num 10
-
   @spec child_spec(InfluxDB.config()) :: Supervisor.child_spec()
   def child_spec(config) do
     config = %{config | port: :erlang.integer_to_binary(config.port)}
@@ -16,7 +14,7 @@ defmodule TelemetryInfluxDB.HTTP.Pool do
       id: pool_name(config.reporter_name),
       start:
         {:wpool, :start_pool,
-         [pool_name(config.reporter_name), [{:workers, @default_workers_num}]]}
+         [pool_name(config.reporter_name), [{:workers, config.worker_pool_size}]]}
     }
   end
 

--- a/lib/telemetry_influx_db.ex
+++ b/lib/telemetry_influx_db.ex
@@ -89,6 +89,7 @@ defmodule TelemetryInfluxDB do
           | {:token, String.t()}
           | {:events, [event]}
           | {:tags, tags}
+          | {:worker_pool_size, non_neg_integer()}
 
   @type options :: [option]
   @type event :: %{required(:name) => :telemetry.event_name()}
@@ -111,6 +112,7 @@ defmodule TelemetryInfluxDB do
       |> Map.put_new(:host, "localhost")
       |> Map.put_new(:port, @default_port)
       |> Map.put_new(:tags, %{})
+      |> Map.put_new(:worker_pool_size, 3)
       |> Map.put_new(:version, :v1)
       |> validate_required!([:events])
       |> validate_event_fields!()


### PR DESCRIPTION
When sending events via HTTP, the `worker_pool` library is used with a hard-coded number of workers (3).

This allows the number of workers to be configured by the client application. The default remains 3 if the client doesn't specify a value.

**NOTE:** Also submitted upstream as https://github.com/ludwikbukowski/telemetry_influxdb/pull/26